### PR TITLE
Adjusting spacing for modal buttons

### DIFF
--- a/elements.import.less
+++ b/elements.import.less
@@ -251,6 +251,10 @@ progress {
         &.dapp-primary-button {
             font-weight: 500;
         }
+
+        &:last-child {
+            margin-right: 0;
+        }
     }
 }
 


### PR DESCRIPTION
Simple PR, removes the right margin from the last button on a modal.
